### PR TITLE
update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,10 @@
 
 ## Review Instructions
 
+[A useful general guide on what to look for in code review](https://google.github.io/eng-practices/review/reviewer/looking-for.html).
+
+Below are Fathom's specific expectations.
+
 ### Required
 
 - Read through the code changes and check that the docs, README and existing tests have been updated.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,6 @@
 
 ## Checklist 
 - [ ] I have run my code and verified that it works as expected
-- [ ] I have requested at least one code review
 - [ ] If functionality has changed, I have added / updated tests
 - [ ] Where/If necessary I have made corresponding changes to documentation
 - [ ] I have added an appropriate label to this PR
@@ -21,6 +20,7 @@
 - Read through the code changes and check that the docs, README and existing tests have been updated.
 - Check that the code is readable and easy to understand. This includes: comments, variable names, method names and line length.
 - Check that the code meets the requirements specified in the PR description and/or linked ClickUp ticket.
+- Verify that all automated checks pass
 
 ### Recommended Best Practices
 


### PR DESCRIPTION
## Description

Some further tweaks to the PR template. Now that reviews are required, we don't need that checkbox anymore. Also adding one for reviewers to check that automated checks (linters/tests etc) are passing.